### PR TITLE
Added support of the JavaScript Engine Switcher version 3.0.0 Beta

### DIFF
--- a/src/JSPool.Example.AspNetCore/JSPool.Example.AspNetCore.csproj
+++ b/src/JSPool.Example.AspNetCore/JSPool.Example.AspNetCore.csproj
@@ -33,12 +33,13 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.0.1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="2.2.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.debian-x64" Version="2.1.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="2.1.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win8-arm" Version="2.1.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="2.1.1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="2.1.1" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.0-beta5" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.0.0-beta3" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.0.0-beta3" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-arm" Version="3.0.0-beta3" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.0.0-beta3" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.0.0-beta3" />
+	<PackageReference Include="JavaScriptEngineSwitcher.Extensions.MsDependencyInjection" Version="3.0.0-beta4" />
   </ItemGroup>
 
   <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">

--- a/src/JSPool.Example.AspNetCore/Startup.cs
+++ b/src/JSPool.Example.AspNetCore/Startup.cs
@@ -7,7 +7,7 @@
 
 using System.IO;
 using JavaScriptEngineSwitcher.ChakraCore;
-using JavaScriptEngineSwitcher.Core;
+using JavaScriptEngineSwitcher.Extensions.MsDependencyInjection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -37,8 +37,11 @@ namespace JSPool.Example.AspNetCore
             services.AddMvc();
 
 			// Configure JavaScriptEngineSwitcher
-	        JsEngineSwitcher.Instance.EngineFactories.AddChakraCore();
-	        JsEngineSwitcher.Instance.DefaultEngineName = ChakraCoreJsEngine.EngineName;
+            services.AddJsEngineSwitcher(options =>
+                options.DefaultEngineName = ChakraCoreJsEngine.EngineName
+            )
+                .AddChakraCore()
+                ;
 
 			// Add JsPool to the dependency injection container
 	        services.AddSingleton<IJsPool>(provider => new JsPool(new JsPoolConfig

--- a/src/JSPool.Example.Console/JSPool.Example.Console.csproj
+++ b/src/JSPool.Example.Console/JSPool.Example.Console.csproj
@@ -23,24 +23,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="2.4.9" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.0.0-beta4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="2.4.2" />
-    <PackageReference Include="JavaScriptEngineSwitcher.V8.Native.win-x64" Version="2.4.2" />
-    <PackageReference Include="JavaScriptEngineSwitcher.V8.Native.win-x86" Version="2.4.2" />
+    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.0.0-beta4" />
+    <PackageReference Include="JavaScriptEngineSwitcher.V8.Native.win-x64" Version="3.0.0-beta3" />
+    <PackageReference Include="JavaScriptEngineSwitcher.V8.Native.win-x86" Version="3.0.0-beta3" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="2.4.8" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.debian-x64" Version="2.4.6" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="2.4.6" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win8-arm" Version="2.4.6" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="2.4.6" />
-    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="2.4.6" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.0.0-beta5" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.0.0-beta3" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.0.0-beta3" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-arm" Version="3.0.0-beta3" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.0.0-beta3" />
+    <PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.0.0-beta3" />
   </ItemGroup>
 
 </Project>

--- a/src/JSPool.Example.Console/Program.cs
+++ b/src/JSPool.Example.Console/Program.cs
@@ -22,12 +22,13 @@ namespace JSPool.Example.ConsoleApp
 		{
 			// Configure JavaScriptEngineSwitcher. Generally V8 is preferred, however
 			// it's currently not supported on .NET Core.
+			IJsEngineSwitcher engineSwitcher = JsEngineSwitcher.Current;
 #if NETCOREAPP1_0
-			JsEngineSwitcher.Instance.EngineFactories.AddChakraCore();
-			JsEngineSwitcher.Instance.DefaultEngineName = ChakraCoreJsEngine.EngineName;
+			engineSwitcher.EngineFactories.AddChakraCore();
+			engineSwitcher.DefaultEngineName = ChakraCoreJsEngine.EngineName;
 #else
-			JsEngineSwitcher.Instance.EngineFactories.AddV8();
-			JsEngineSwitcher.Instance.DefaultEngineName = V8JsEngine.EngineName;
+			engineSwitcher.EngineFactories.AddV8();
+			engineSwitcher.DefaultEngineName = V8JsEngine.EngineName;
 #endif
 
 			var pool = new JsPool(new JsPoolConfig

--- a/src/JSPool.Example.Web/App_Start/JsPoolInitializer.cs
+++ b/src/JSPool.Example.Web/App_Start/JsPoolInitializer.cs
@@ -16,8 +16,9 @@ namespace JSPool.Example.Web
 		public static void Initialize()
 		{
 			// Configure JavaScriptEngineSwitcher
-			JsEngineSwitcher.Instance.EngineFactories.AddV8();
-			JsEngineSwitcher.Instance.DefaultEngineName = V8JsEngine.EngineName;
+			IJsEngineSwitcher engineSwitcher = JsEngineSwitcher.Current;
+			engineSwitcher.EngineFactories.AddV8();
+			engineSwitcher.DefaultEngineName = V8JsEngine.EngineName;
 
 			// Ideally this would use an IoC container, but I'm just using HttpApplicationState
 			// to keep the example simple.

--- a/src/JSPool.Example.Web/JSPool.Example.Web.csproj
+++ b/src/JSPool.Example.Web/JSPool.Example.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.2.4.2\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props" Condition="Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.2.4.2\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props')" />
-  <Import Project="..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.2.4.2\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props" Condition="Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.2.4.2\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" />
+  <Import Project="..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props" Condition="Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props')" />
+  <Import Project="..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props" Condition="Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -46,21 +46,24 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ClearScript, Version=5.4.9.0, Culture=neutral, PublicKeyToken=935d0c957da47c73, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.2.4.2\lib\net45\ClearScript.dll</HintPath>
+    <Reference Include="ClearScript, Version=5.5.2.0, Culture=neutral, PublicKeyToken=935d0c957da47c73, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.3.0.0-beta4\lib\net45\ClearScript.dll</HintPath>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.Core, Version=2.4.9.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.2.4.9\lib\net45\JavaScriptEngineSwitcher.Core.dll</HintPath>
+    <Reference Include="JavaScriptEngineSwitcher.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.Core.3.0.0-beta4\lib\net45\JavaScriptEngineSwitcher.Core.dll</HintPath>
     </Reference>
-    <Reference Include="JavaScriptEngineSwitcher.V8, Version=2.4.2.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
-      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.2.4.2\lib\net45\JavaScriptEngineSwitcher.V8.dll</HintPath>
+    <Reference Include="JavaScriptEngineSwitcher.V8, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c608b2a8cc9e4472, processorArchitecture=MSIL">
+      <HintPath>..\packages\JavaScriptEngineSwitcher.V8.3.0.0-beta4\lib\net45\JavaScriptEngineSwitcher.V8.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Web.Infrastructure">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="MsieJavaScriptEngine, Version=2.2.2.0, Culture=neutral, PublicKeyToken=a3a2846a37ac0d3e, processorArchitecture=MSIL">
-      <HintPath>..\packages\MsieJavaScriptEngine.2.2.2\lib\net45\MsieJavaScriptEngine.dll</HintPath>
+    <Reference Include="MsieJavaScriptEngine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a3a2846a37ac0d3e, processorArchitecture=MSIL">
+      <HintPath>..\packages\MsieJavaScriptEngine.3.0.0-beta4\lib\net45\MsieJavaScriptEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
@@ -169,8 +172,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.2.4.2\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.2.4.2\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props'))" />
-    <Error Condition="!Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.2.4.2\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.2.4.2\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props'))" />
+    <Error Condition="!Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptEngineSwitcher.V8.Native.win-x64.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x64.props'))" />
+    <Error Condition="!Exists('..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptEngineSwitcher.V8.Native.win-x86.3.0.0-beta3\build\JavaScriptEngineSwitcher.V8.Native.win-x86.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/JSPool.Example.Web/packages.config
+++ b/src/JSPool.Example.Web/packages.config
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="JavaScriptEngineSwitcher.Core" version="2.4.9" targetFramework="net451" />
-  <package id="JavaScriptEngineSwitcher.V8" version="2.4.2" targetFramework="net451" />
-  <package id="JavaScriptEngineSwitcher.V8.Native.win-x64" version="2.4.2" targetFramework="net451" />
-  <package id="JavaScriptEngineSwitcher.V8.Native.win-x86" version="2.4.2" targetFramework="net451" />
+  <package id="JavaScriptEngineSwitcher.Core" version="3.0.0-beta4" targetFramework="net451" />
+  <package id="JavaScriptEngineSwitcher.V8" version="3.0.0-beta4" targetFramework="net451" />
+  <package id="JavaScriptEngineSwitcher.V8.Native.win-x64" version="3.0.0-beta3" targetFramework="net451" />
+  <package id="JavaScriptEngineSwitcher.V8.Native.win-x86" version="3.0.0-beta3" targetFramework="net451" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net451" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net451" />
-  <package id="MsieJavaScriptEngine" version="2.2.2" targetFramework="net451" />
+  <package id="MsieJavaScriptEngine" version="3.0.0-beta4" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net451" />
 </packages>

--- a/src/JSPool/JSPool.csproj
+++ b/src/JSPool/JSPool.csproj
@@ -34,7 +34,7 @@ See https://dan.cx/projects/jspool for usage instructions.</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="2.4.9" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.0.0-beta4" />
   </ItemGroup>
 
 

--- a/src/JSPool/JavaScriptEngineSwitcherPoolConfig.cs
+++ b/src/JSPool/JavaScriptEngineSwitcherPoolConfig.cs
@@ -19,7 +19,7 @@ namespace JSPool
 		/// </summary>
 		public JsPoolConfig()
 		{
-			EngineFactory = JsEngineSwitcher.Instance.CreateDefaultEngine;
+			EngineFactory = JsEngineSwitcher.Current.CreateDefaultEngine;
 		}
 	}
 }

--- a/src/JSPool/PooledJsEngine.cs
+++ b/src/JSPool/PooledJsEngine.cs
@@ -20,24 +20,89 @@ namespace JSPool
 	{
 		#region IJsEngine implementation
 		/// <summary>
-		/// Gets the name of this JavaScript engine
+		/// Gets the name of this JS engine
 		/// </summary>
 		public string Name => InnerEngine.Name;
 
 		/// <summary>
-		/// Gets the version of this JavaScript engine
+		/// Gets the version of this JS engine
 		/// </summary>
 		public string Version => InnerEngine.Version;
 
 		/// <summary>
-		/// Determines if this engine supports garbage collection.
+		/// Determines if this engine supports script pre-compilation
+		/// </summary>
+		public bool SupportsScriptPrecompilation => InnerEngine.SupportsScriptPrecompilation;
+
+		/// <summary>
+		/// Determines if this engine supports script interruption
+		/// </summary>
+		public bool SupportsScriptInterruption => InnerEngine.SupportsScriptInterruption;
+
+		/// <summary>
+		/// Determines if this engine supports garbage collection
 		/// </summary>
 		public bool SupportsGarbageCollection => InnerEngine.SupportsGarbageCollection;
 
 		/// <summary>
+		/// Creates a pre-compiled script from JS code
+		/// </summary>
+		/// <param name="code">JS code</param>
+		/// <returns>A pre-compiled script that can be executed by different instances of JS engine</returns>
+		public virtual IPrecompiledScript Precompile(string code)
+		{
+			return InnerEngine.Precompile(code);
+		}
+
+		/// <summary>
+		/// Creates a pre-compiled script from JS code
+		/// </summary>
+		/// <param name="code">JS code</param>
+		/// <param name="documentName">Document name</param>
+		/// <returns>A pre-compiled script that can be executed by different instances of JS engine</returns>
+		public virtual IPrecompiledScript Precompile(string code, string documentName)
+		{
+			return InnerEngine.Precompile(code, documentName);
+		}
+
+		/// <summary>
+		/// Creates a pre-compiled script from JS file
+		/// </summary>
+		/// <param name="path">Path to the JS file</param>
+		/// <param name="encoding">Text encoding</param>
+		/// <returns>A pre-compiled script that can be executed by different instances of JS engine</returns>
+		public virtual IPrecompiledScript PrecompileFile(string path, Encoding encoding = null)
+		{
+			return InnerEngine.PrecompileFile(path, encoding);
+		}
+
+		/// <summary>
+		/// Creates a pre-compiled script from embedded JS resource
+		/// </summary>
+		/// <param name="resourceName">The case-sensitive resource name without the namespace of the specified type</param>
+		/// <param name="type">The type, that determines the assembly and whose namespace is used to scope
+		/// the resource name</param>
+		/// <returns>A pre-compiled script that can be executed by different instances of JS engine</returns>
+		public virtual IPrecompiledScript PrecompileResource(string resourceName, Type type)
+		{
+			return InnerEngine.PrecompileResource(resourceName, type);
+		}
+
+		/// <summary>
+		/// Creates a pre-compiled script from embedded JS resource
+		/// </summary>
+		/// <param name="resourceName">The case-sensitive resource name</param>
+		/// <param name="assembly">The assembly, which contains the embedded resource</param>
+		/// <returns>A pre-compiled script that can be executed by different instances of JS engine</returns>
+		public virtual IPrecompiledScript PrecompileResource(string resourceName, Assembly assembly)
+		{
+			return InnerEngine.PrecompileResource(resourceName, assembly);
+		}
+
+		/// <summary>
 		/// Evaluates an expression
 		/// </summary>
-		/// <param name="expression">JS-expression</param>
+		/// <param name="expression">JS expression</param>
 		/// <returns>Result of the expression</returns>
 		public virtual object Evaluate(string expression)
 		{
@@ -47,28 +112,70 @@ namespace JSPool
 		/// <summary>
 		/// Evaluates an expression
 		/// </summary>
+		/// <param name="expression">JS expression</param>
+		/// <param name="documentName">Document name</param>
+		/// <returns>Result of the expression</returns>
+		public virtual object Evaluate(string expression, string documentName)
+		{
+			return InnerEngine.Evaluate(expression, documentName);
+		}
+
+		/// <summary>
+		/// Evaluates an expression
+		/// </summary>
 		/// <typeparam name="T">Type of result</typeparam>
-		/// <param name="expression">JS-expression</param>
+		/// <param name="expression">JS expression</param>
 		/// <returns>Result of the expression</returns>
 		public virtual T Evaluate<T>(string expression)
 		{
 			return InnerEngine.Evaluate<T>(expression);
 		}
 
+		/// <summary>
+		/// Evaluates an expression
+		/// </summary>
+		/// <typeparam name="T">Type of result</typeparam>
+		/// <param name="expression">JS expression</param>
+		/// <param name="documentName">Document name</param>
+		/// <returns>Result of the expression</returns>
+		public virtual T Evaluate<T>(string expression, string documentName)
+		{
+			return InnerEngine.Evaluate<T>(expression, documentName);
+		}
 
 		/// <summary>
 		/// Executes a code
 		/// </summary>
-		/// <param name="code">Code</param>
+		/// <param name="code">JS code</param>
 		public virtual void Execute(string code)
 		{
 			InnerEngine.Execute(code);
 		}
 
 		/// <summary>
-		/// Executes a code from JS-file
+		/// Executes a code
 		/// </summary>
-		/// <param name="path">Path to the JS-file</param>
+		/// <param name="code">JS code</param>
+		/// <param name="documentName">Document name</param>
+		public virtual void Execute(string code, string documentName)
+		{
+			InnerEngine.Execute(code, documentName);
+		}
+
+		/// <summary>
+		/// Executes a pre-compiled script
+		/// </summary>
+		/// <param name="precompiledScript">A pre-compiled script that can be executed by different
+		/// instances of JS engine</param>
+		public virtual void Execute(IPrecompiledScript precompiledScript)
+		{
+			InnerEngine.Execute(precompiledScript);
+		}
+
+		/// <summary>
+		/// Executes a code from JS file
+		/// </summary>
+		/// <param name="path">Path to the JS file</param>
 		/// <param name="encoding">Text encoding</param>
 		public virtual void ExecuteFile(string path, Encoding encoding = null)
 		{
@@ -76,20 +183,21 @@ namespace JSPool
 		}
 
 		/// <summary>
-		/// Executes a code from embedded JS-resource
+		/// Executes a code from embedded JS resource
 		/// </summary>
-		/// <param name="resourceName">JS-resource name</param>
-		/// <param name="type">Type from assembly that containing an embedded resource</param>
+		/// <param name="resourceName">The case-sensitive resource name without the namespace of the specified type</param>
+		/// <param name="type">The type, that determines the assembly and whose namespace is used to scope
+		/// the resource name</param>
 		public virtual void ExecuteResource(string resourceName, Type type)
 		{
 			InnerEngine.ExecuteResource(resourceName, type);
 		}
 
 		/// <summary>
-		/// Executes a code from embedded JS-resource
+		/// Executes a code from embedded JS resource
 		/// </summary>
-		/// <param name="resourceName">JS-resource name</param>
-		/// <param name="assembly">Assembly that containing an embedded resource</param>
+		/// <param name="resourceName">The case-sensitive resource name</param>
+		/// <param name="assembly">The assembly, which contains the embedded resource</param>
 		public virtual void ExecuteResource(string resourceName, Assembly assembly)
 		{
 			InnerEngine.ExecuteResource(resourceName, assembly);
@@ -169,64 +277,44 @@ namespace JSPool
 		}
 
 		/// <summary>
-		/// Embeds a .NET object in the JavaScript engine.
+		/// Embeds a .NET object in the JS engine
 		/// </summary>
 		/// <param name="itemName">Name of the item</param>
 		/// <param name="value">Value of the item</param>
+		/// <remarks>Allows to embed instances of simple classes (or structures) and delegates.</remarks>
 		public virtual void EmbedHostObject(string itemName, object value)
 		{
 			InnerEngine.EmbedHostObject(itemName, value);
 		}
 
 		/// <summary>
-		/// Embeds a .NET type in the JavaScript engine.
+		/// Embeds a .NET type in the JS engine
 		/// </summary>
 		/// <param name="itemName">Name of the type</param>
 		/// <param name="type">The type</param>
+		/// <remarks>
+		/// .NET types are exposed to script code in the form of objects whose properties and
+		/// methods are bound to the type's static members.
+		/// </remarks>
 		public virtual void EmbedHostType(string itemName, Type type)
 		{
 			InnerEngine.EmbedHostType(itemName, type);
 		}
 
 		/// <summary>
-		/// Collects the garbage.
+		/// Interrupts script execution and causes the JS engine to throw an exception
+		/// </summary>
+		public virtual void Interrupt()
+		{
+			InnerEngine.Interrupt();
+		}
+
+		/// <summary>
+		/// Collects the garbage
 		/// </summary>
 		public virtual void CollectGarbage()
 		{
 			InnerEngine.CollectGarbage();
-		}
-
-		/// <summary>
-		/// Evaluates an expression
-		/// </summary>
-		/// <param name="expression">JS-expression</param>
-		/// <param name="documentName">Document name</param>
-		/// <returns>Result of the expression</returns>
-		public virtual object Evaluate(string expression, string documentName)
-		{
-			return InnerEngine.Evaluate(expression, documentName);
-		}
-
-		/// <summary>
-		/// Evaluates an expression
-		/// </summary>
-		/// <typeparam name="T">Type of result</typeparam>
-		/// <param name="expression">JS-expression</param>
-		/// <param name="documentName">Document name</param>
-		/// <returns>Result of the expression</returns>
-		public virtual T Evaluate<T>(string expression, string documentName)
-		{
-			return InnerEngine.Evaluate<T>(expression, documentName);
-		}
-
-		/// <summary>
-		/// Executes a code
-		/// </summary>
-		/// <param name="code">JS-code</param>
-		/// <param name="documentName">Document name</param>
-		public virtual void Execute(string code, string documentName)
-		{
-			InnerEngine.Execute(code, documentName);
 		}
 		#endregion
 	}


### PR DESCRIPTION
Hello, Daniel!

JavaScript Engine Switcher version 3.X  has moved to the stabilization phase. I think that it's time to release beta versions of the JSPool and ReactJS.NET.

Main changes you can find in the [“How to upgrade applications to version 3.X”](https://github.com/Taritsyn/JavaScriptEngineSwitcher/wiki/How-to-upgrade-applications-to-version-3.X) section of documentation.